### PR TITLE
convert to python

### DIFF
--- a/reusable/cloudant-rewinds/README.md
+++ b/reusable/cloudant-rewinds/README.md
@@ -18,17 +18,11 @@ In [1]: from pillowtop.utils import get_all_pillows
 In [2]: for pillow in get_all_pillows():
    ...:     print pillow.get_checkpoint()
 ```
-or for a single pillow:
-```python
-In [1]: from pillowtop.utils import get_pillow_by_name
-In [2]: pillow = get_pillow_by_name(pillow_name)
-In [3]: print pillow.get_checkpoint()
-```
 
 Copy the output (one checkpoint doc per line, ending with a new line) into a file named checkpoint_docs.txt. Then run the following:
 
 ```bash
-while read line; do echo $line | jsawk 'return this._id + " " + this.seq'; done < checkpoint_docs.txt | sed 's/^.*\.\([A-Z][A-Za-z]*Pillow\)[^ ]* \([0-9]*\)-.*$/\2 \1/' | sort -n
+./extract_seq.py -f checkpoint_docs.txt
 ```
 
 The output may look something like
@@ -47,7 +41,7 @@ The output may look something like
 The first few will have checkpoint numbers significantly smaller than the rest. Those are the pillows that are in a rewind state and need to be reset to a reasonable `seq`. In this example it's the first 5 that are the problem. Based on that run a command like the following
 
 ```bash
-while read line; do echo $line | jsawk 'return this._id'; done < checkpoint_docs.txt | grep -E 'XFormPillow|FormDataPillow|CasePillow|CaseDataPillow|ReportCasePillow' > pillow_checkpoint_ids
+./extract_seq.py -f checkpoint_docs.txt -l5 --id_only > pillow_checkpoint_ids
 ```
 
 to pull just the full checkpoint _ids for the pillows you want.

--- a/reusable/cloudant-rewinds/extract_seq.py
+++ b/reusable/cloudant-rewinds/extract_seq.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# Usage:
+#   ./extract_seq.py checkpoint_docs.txt
+
+import json
+import re
+import sys
+import argparse
+
+name_rx = re.compile('^.*\.([A-Z][A-Za-z]*Pillow)')
+
+
+def get_docs(file_path):
+    with open(file_path, 'r') as f:
+        return f.readlines()
+
+
+def extract_doc_id_seq(doc, full_ids=False):
+    doc = doc.replace("'", '"')
+    doc_json = json.loads(doc)
+    full_id = doc_json['_id']
+    id = full_id if full_ids else name_rx.match(full_id).group(1)
+    seq = doc_json['seq'].split('-')[0]
+    return id, seq
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process pillow checkpoints.')
+    parser.add_argument('-f', '--file', default='checkpoint_docs.txt', help='Path to file containing checkpoint docs')
+    parser.add_argument('-l', '--limit', type=int)
+    parser.add_argument('--id_only', dest='id_only', action='store_true',
+                       help='Only print out the full IDs')
+
+    args = parser.parse_args()
+    file_path = args.file
+    limit = args.limit
+    ids_only = args.id_only
+
+    docs = get_docs(file_path)
+    id_seq = sorted([extract_doc_id_seq(doc, ids_only) for doc in docs], key=lambda x: x[1])
+    if limit:
+        id_seq = id_seq[:limit]
+    for doc_id, seq in id_seq:
+        if ids_only:
+            print doc_id
+        else:
+            print '{} {}'.format(seq, doc_id)


### PR DESCRIPTION
Getting jsawk to run on Linux requires installing the full JS runtime manually which seems unnecessary. I started converting to python but then stopped when I realized I can't access prod Cloudant from my machine anyway.

@dannyroberts @benrudolph 
